### PR TITLE
refactor: remove duplicate trial link assignment

### DIFF
--- a/xpace-landing/assets/js/app.js
+++ b/xpace-landing/assets/js/app.js
@@ -161,7 +161,7 @@ const cta = h.reservado ? '' : `
 const y = el('#year'); if (y) y.textContent = new Date().getFullYear()
 
 // Preenche link do trial nos botões do hero, se existir
-const btnTrialHero = document.getElementById('btn-trial-hero');
+const btnTrialHero = el('#btn-trial-hero');
 if (btnTrialHero) btnTrialHero.href = LINKS.trial;
 
 
@@ -204,8 +204,6 @@ if (blobs.length){
   }, {passive:true})
 }
 
-const btnTrialHero = document.getElementById('btn-trial-hero');
-if (btnTrialHero) btnTrialHero.href = LINKS.trial;
 
 /* ===== Awards (premiações) ===== */
 const AWARDS = [


### PR DESCRIPTION
## Summary
- remove duplicate `btnTrialHero` logic in app script
- use helper function for cleaner DOM selection

## Testing
- `node --check assets/js/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0984e3c4c8330b7badd9afe7537f4