### PR TITLE
Fix teacher photo paths

### DIFF
--- a/xpace-landing/assets/js/app.js
+++ b/xpace-landing/assets/js/app.js
@@ -93,7 +93,7 @@ const HORARIOS = [
 const tWrap = el('#teachers-target')
 if (tWrap){
   TEACHERS.forEach(t => {
-    const imgSrc = t.photo ? `assets/images/teachers/${t.photo}` : `https://unavatar.io/instagram/${t.ig}`
+    const imgSrc = t.photo ? t.photo : `https://unavatar.io/instagram/${t.ig}`
     const card = $(`<li class="teacher-card reveal">
       <img src="${imgSrc}" alt="Foto de ${t.name}">
       <div class="info">


### PR DESCRIPTION
## Summary
- fix teacher photo paths to avoid double folder

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d2e7709083308543efc038601508