### PR TITLE
feat: add responsive awards timeline

### DIFF
--- a/xpace-landing/assets/css/styles.css
+++ b/xpace-landing/assets/css/styles.css
@@ -75,6 +75,20 @@ h2{font-size:28px;margin:0 0 16px 0}
 .day li{padding:10px;border-top:1px solid var(--line)}
 .day li:first-child{border-top:0}
 
+/* Timeline */
+.timeline{position:relative;margin:40px 0;display:flex;flex-direction:column;gap:40px}
+.timeline::before{content:'';position:absolute;left:20px;top:0;bottom:0;width:4px;background:var(--line)}
+.timeline-item{position:relative;padding-left:60px}
+.timeline-node{position:absolute;left:0;top:0;width:40px;height:40px;border-radius:50%;background:linear-gradient(135deg,var(--primary),var(--accent));display:flex;align-items:center;justify-content:center;font-size:20px;color:#fff;box-shadow:var(--shadow)}
+.timeline-content{border:1px solid var(--line);border-radius:var(--radius);padding:16px;background:rgba(255,255,255,.03)}
+@media (min-width:768px){
+  .timeline{flex-direction:row;padding:20px 0}
+  .timeline::before{left:0;right:0;top:20px;bottom:auto;width:auto;height:4px}
+  .timeline-item{flex:1;padding-left:0;padding-top:60px;text-align:center}
+  .timeline-node{left:50%;top:0;transform:translate(-50%,-50%)}
+  .timeline-content{margin-top:0}
+}
+
 /* Footer */
 .site-footer{padding:24px 0;border-top:1px solid var(--line)}
 

--- a/xpace-landing/assets/js/app.js
+++ b/xpace-landing/assets/js/app.js
@@ -160,15 +160,18 @@ const AWARDS = [
 
 /* ===== Render: Premiações ===== */
 (function renderAwards(){
-  const wrap = $('#awards-list'); if (!wrap) return;
+  const wrap = $('#awards-timeline'); if (!wrap) return;
   AWARDS.forEach(a=>{
-    const note = a.note ? `<div class="muted small mt-sm">${a.note}</div>` : '';
+    const note = a.note ? `<small class=\"muted block mt-sm\">${a.note}</small>` : '';
     wrap.append($h(`
-      <li class="card reveal" style="border-left:4px solid var(--primary)">
-        <strong>${a.year} — ${a.title}</strong>
-        <div class="mt-sm">${a.desc}</div>
-        ${note}
-      </li>
+      <div class=\"timeline-item reveal\">
+        <div class=\"timeline-node\">🏆</div>
+        <div class=\"timeline-content\">
+          <strong>${a.year} — ${a.title}</strong>
+          <div class=\"mt-sm\">${a.desc}</div>
+          ${note}
+        </div>
+      </div>
     `));
   });
 })();

--- a/xpace-landing/index.html
+++ b/xpace-landing/index.html
@@ -91,7 +91,7 @@
     <section id="premiacoes" class="section">
       <div class="container">
         <h2 class="reveal">Premiações</h2>
-        <ul id="awards-list" class="grid three list-plain"></ul>
+        <div id="awards-timeline" class="timeline"></div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- replace awards grid with timeline structure
- style and render awards as responsive timeline with trophy nodes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a47e2f1f308330942968936e160483