### PR TITLE
Add animated top loading bar

### DIFF
--- a/xpace-landing/assets/css/styles.css
+++ b/xpace-landing/assets/css/styles.css
@@ -95,3 +95,8 @@ h2{font-size:28px;margin:0 0 16px 0}
 /* Reveal animation */
 .reveal{opacity:0;transform:translateY(20px);transition:opacity .6s ease,transform .6s ease}
 .reveal.show{opacity:1;transform:none}
+
+/* Loader */
+#top-loader{position:fixed;top:0;left:0;width:100%;height:4px;z-index:100;background:linear-gradient(90deg,var(--primary),var(--secondary),var(--accent));background-size:200% 100%;animation:loader 1s linear infinite;pointer-events:none;transition:opacity .3s}
+#top-loader.hide{opacity:0}
+@keyframes loader{from{background-position:0 0}to{background-position:200% 0}}

--- a/xpace-landing/assets/js/app.js
+++ b/xpace-landing/assets/js/app.js
@@ -234,3 +234,12 @@ const AWARDS = [
     setInterval(()=>{ hi=(hi+1)%HERO_MEDIA.length; apply(); }, 4000);
   }
 })();
+
+/* ===== Loader ===== */
+window.addEventListener('load', ()=>{
+  const bar = $('#top-loader');
+  if (bar){
+    bar.classList.add('hide');
+    setTimeout(()=>bar.remove(),300);
+  }
+});

--- a/xpace-landing/index.html
+++ b/xpace-landing/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body class="theme-dark">
+  <div id="top-loader"></div>
   <!-- Header -->
   <header class="site-header">
     <div class="container row-between">


### PR DESCRIPTION
## Summary
- show minimal gradient loader at top of page during load
- hide loader after page assets finish loading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a48280c1348330863dca03107d3615