### PR TITLE
Update color scheme and fonts

### DIFF
--- a/xpace-landing/assets/css/styles.css
+++ b/xpace-landing/assets/css/styles.css
@@ -1,8 +1,8 @@
 :root{
   --bg:#0c0c0f; --panel:#121216; --text:#f3f3f5; --muted:#b9b9c6; --line:rgba(255,255,255,.08);
-  --primary:#a78bfa; --secondary:#22d3ee; --accent:#7c3aed;
+  --primary:#a78bfa; --secondary:#f97316; --accent:#7c3aed;
   --radius:16px; --shadow:0 10px 30px rgba(0,0,0,.35);
-  --font:-apple-system, system-ui, "Inter", "SF Pro Display", Segoe UI, Roboto, Arial, sans-serif;
+  --font:"SF Pro Rounded", "SF Pro Display", -apple-system, system-ui, "Inter", "Segoe UI", Roboto, Arial, sans-serif;
 }
 *{box-sizing:border-box}
 html,body{margin:0;padding:0;color:var(--text);background:var(--bg);font-family:var(--font)}


### PR DESCRIPTION
## Summary
- Replace blue accent with orange and keep purple theme
- Use rounded, professional Apple-style font stack

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4850715c48330a318a3f62fa75db8