### PR TITLE
feat: add light theme toggle

### DIFF
--- a/xpace-landing/assets/css/styles.css
+++ b/xpace-landing/assets/css/styles.css
@@ -1,7 +1,15 @@
-:root{
+:root,
+body.theme-dark{
   --bg:#0c0c0f; --panel:#121216; --text:#f3f3f5; --muted:#b9b9c6; --line:rgba(255,255,255,.08);
   --primary:#a78bfa; --secondary:#f97316; --accent:#7c3aed;
   --radius:16px; --shadow:0 10px 30px rgba(0,0,0,.35);
+  --font:"SF Pro Rounded", "SF Pro Display", -apple-system, system-ui, "Inter", "Segoe UI", Roboto, Arial, sans-serif;
+}
+
+body.theme-light{
+  --bg:#fdfdfd; --panel:#ffffff; --text:#0c0c0f; --muted:#4b4b5c; --line:rgba(0,0,0,.1);
+  --primary:#a78bfa; --secondary:#f97316; --accent:#7c3aed;
+  --radius:16px; --shadow:0 10px 30px rgba(0,0,0,.1);
   --font:"SF Pro Rounded", "SF Pro Display", -apple-system, system-ui, "Inter", "Segoe UI", Roboto, Arial, sans-serif;
 }
 *{box-sizing:border-box}

--- a/xpace-landing/assets/js/app.js
+++ b/xpace-landing/assets/js/app.js
@@ -3,6 +3,28 @@ const $  = (sel) => document.querySelector(sel);
 const $$ = (sel) => Array.from(document.querySelectorAll(sel));
 const $h = (html) => { const t = document.createElement('template'); t.innerHTML = html.trim(); return t.content.firstChild; };
 
+/* ===== Theme toggle ===== */
+(function initTheme(){
+  const storageKey = 'theme';
+  const body = document.body;
+  const btn = document.getElementById('theme-toggle');
+  const apply = (theme) => {
+    body.classList.remove('theme-light','theme-dark');
+    body.classList.add(`theme-${theme}`);
+    if (btn) btn.textContent = theme === 'light' ? '🌙' : '☀️';
+  };
+  let theme = localStorage.getItem(storageKey);
+  if (!theme){
+    theme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+  }
+  apply(theme);
+  btn?.addEventListener('click', ()=>{
+    theme = body.classList.contains('theme-light') ? 'dark' : 'light';
+    apply(theme);
+    localStorage.setItem(storageKey, theme);
+  });
+})();
+
 /* ===== Reveal on scroll ===== */
 (function initReveal(){
   if (!('IntersectionObserver' in window)) return;

--- a/xpace-landing/index.html
+++ b/xpace-landing/index.html
@@ -27,6 +27,7 @@
         <a class="btn small ghost" id="btn-trial-nav" target="_blank" rel="noreferrer">Aula experimental</a>
       </nav>
       <a class="btn primary pill cta-pulse" id="btn-matriculas" target="_blank" rel="noreferrer">Matrículas</a>
+      <button id="theme-toggle" class="btn small ghost" aria-label="Alternar tema">🌙</button>
       <button class="burger" aria-label="Abrir menu" aria-expanded="false"></button>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- add light theme variables and toggle button
- switch theme based on localStorage or system preference

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a496f9257c8330b28e61ad953c0550