### PR TITLE
feat: add schedule filters

### DIFF
--- a/xpace-landing/assets/js/app.js
+++ b/xpace-landing/assets/js/app.js
@@ -108,14 +108,20 @@ const AWARDS = [
 })();
 
 /* ===== Render: Horários ===== */
-(function renderSchedule(){
+function renderHorarios(){
   const sWrap = $('#schedule-target'); if (!sWrap) return;
+  sWrap.innerHTML = '';
   const weekOrder=['seg','ter','qua','qui','sex','sab'];
   const weekName={seg:'Segunda',ter:'Terça',qua:'Quarta',qui:'Quinta',sex:'Sexta',sab:'Sábado'};
+  const diaSel = $('#filter-dia')?.value || '';
+  const modSel = $('#filter-modalidade')?.value || '';
   weekOrder.forEach(dia=>{
-    const items = HORARIOS.filter(h=>h.dias.includes(dia)).sort((a,b)=>a.hora.localeCompare(b.hora));
+    if (diaSel && dia !== diaSel) return;
+    const items = HORARIOS
+      .filter(h=>h.dias.includes(dia) && (!modSel || h.modalidade === modSel))
+      .sort((a,b)=>a.hora.localeCompare(b.hora));
     if (!items.length) return;
-    const col = $h(`<div class="day reveal"><h3>${weekName[dia]}</h3><ul></ul></div>`);
+    const col = $h(`<div class="day reveal" data-dia="${dia}"><h3>${weekName[dia]}</h3><ul></ul></div>`);
     const list = col.querySelector('ul');
     items.forEach(h=>{
       const tag = h.reservado ? '🔒 Reservado' : (h.faixa || '');
@@ -128,7 +134,7 @@ const AWARDS = [
           </a>
         </div>`;
       const li = $h(`
-        <li class="reveal">
+        <li class="reveal" data-modalidade="${h.modalidade}">
           <div class="row"><b>${h.hora}</b> • ${h.dur || 60} min</div>
           <div class="muted small">${h.modalidade} • ${h.grupo} • ${h.nivel} ${tag?`• ${tag}`:''}</div>
           <div class="muted small">Professor(a): ${h.professor}</div>
@@ -139,7 +145,7 @@ const AWARDS = [
     });
     sWrap.append(col);
   });
-})();
+}
 
 /* ===== Render: Planos ===== */
 (function renderPlans(){
@@ -189,6 +195,26 @@ const AWARDS = [
   $('#link-whats')?.setAttribute('href', LINKS.whats);
   if ($('#link-whats')) $('#link-whats').textContent = '+55 47 99946‑3474';
   $('#btn-matriculas')?.setAttribute('href', LINKS.matriculas);
+
+  // filtros de horários
+  const fDia = $('#filter-dia');
+  const fMod = $('#filter-modalidade');
+  try {
+    const sd = localStorage.getItem('filterDia');
+    const sm = localStorage.getItem('filterModalidade');
+    if (fDia && sd) fDia.value = sd;
+    if (fMod && sm) fMod.value = sm;
+  } catch(e) {}
+  fDia?.addEventListener('change', ()=>{
+    try { localStorage.setItem('filterDia', fDia.value); } catch(e) {}
+    renderHorarios();
+  });
+  fMod?.addEventListener('change', ()=>{
+    try { localStorage.setItem('filterModalidade', fMod.value); } catch(e) {}
+    renderHorarios();
+  });
+
+  renderHorarios();
 
   // menu mobile
   const burger = document.querySelector('.burger');

--- a/xpace-landing/index.html
+++ b/xpace-landing/index.html
@@ -65,6 +65,29 @@
     <section id="horarios" class="section">
       <div class="container">
         <h2 class="reveal">Horários</h2>
+        <div class="row gap-sm mt-sm">
+          <select id="filter-dia">
+            <option value="">Todos os dias</option>
+            <option value="seg">Segunda</option>
+            <option value="ter">Terça</option>
+            <option value="qua">Quarta</option>
+            <option value="qui">Quinta</option>
+            <option value="sex">Sexta</option>
+            <option value="sab">Sábado</option>
+          </select>
+          <select id="filter-modalidade">
+            <option value="">Todas as modalidades</option>
+            <option value="Acrobacias">Acrobacias</option>
+            <option value="Contemporâneo">Contemporâneo</option>
+            <option value="Danças Urbanas">Danças Urbanas</option>
+            <option value="Dança de Salão">Dança de Salão</option>
+            <option value="Ensaio CIA">Ensaio CIA</option>
+            <option value="Heels">Heels</option>
+            <option value="Jazz">Jazz</option>
+            <option value="Jazz Funk">Jazz Funk</option>
+            <option value="Ritmos">Ritmos</option>
+          </select>
+        </div>
         <div id="schedule-target" class="grid three"></div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add filtering controls for schedule by day and modality
- render schedule respecting selected filters and mark items with data attributes
- remember selected filters using localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a49700d5bc8330a6c31cad140de0d8