### PR TITLE
Add contact form with Formspree integration

### DIFF
--- a/xpace-landing/assets/css/styles.css
+++ b/xpace-landing/assets/css/styles.css
@@ -92,6 +92,15 @@ h2{font-size:28px;margin:0 0 16px 0}
 /* Footer */
 .site-footer{padding:24px 0;border-top:1px solid var(--line)}
 
+/* Contact form */
+#contact-form{display:flex;flex-direction:column;gap:10px}
+#contact-form label{font-size:14px}
+#contact-form input,#contact-form textarea{padding:10px;border:1px solid var(--line);border-radius:10px;background:rgba(255,255,255,.03);color:var(--text)}
+#contact-form textarea{min-height:120px;resize:vertical}
+#form-status{min-height:20px;font-size:14px}
+#form-status.success{color:#4ade80}
+#form-status.error{color:#f87171}
+
 /* Reveal animation */
 .reveal{opacity:0;transform:translateY(24px) scale(.98);transition:opacity .6s cubic-bezier(.43,0,.36,1),transform .7s cubic-bezier(.43,0,.36,1);will-change:opacity,transform}
 .reveal.show{opacity:1;transform:none}

--- a/xpace-landing/assets/js/app.js
+++ b/xpace-landing/assets/js/app.js
@@ -233,6 +233,42 @@ const AWARDS = [
     apply();
     setInterval(()=>{ hi=(hi+1)%HERO_MEDIA.length; apply(); }, 4000);
   }
+
+  // contato - envio de formulário
+  const contactForm = $('#contact-form');
+  const formStatus = $('#form-status');
+  if (contactForm) {
+    contactForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      if (!contactForm.checkValidity()) {
+        contactForm.reportValidity();
+        return;
+      }
+      formStatus.textContent = 'Enviando...';
+      try {
+        const data = new FormData(contactForm);
+        const res = await fetch('https://formspree.io/f/xjkvzvgz', {
+          method: 'POST',
+          body: data,
+          headers: { 'Accept': 'application/json' }
+        });
+        if (res.ok) {
+          formStatus.textContent = 'Mensagem enviada com sucesso!';
+          formStatus.classList.add('success');
+          formStatus.classList.remove('error');
+          contactForm.reset();
+        } else {
+          formStatus.textContent = 'Ocorreu um erro. Tente novamente.';
+          formStatus.classList.add('error');
+          formStatus.classList.remove('success');
+        }
+      } catch (err) {
+        formStatus.textContent = 'Ocorreu um erro. Tente novamente.';
+        formStatus.classList.add('error');
+        formStatus.classList.remove('success');
+      }
+    });
+  }
 })();
 
 /* ===== Loader ===== */

--- a/xpace-landing/index.html
+++ b/xpace-landing/index.html
@@ -117,6 +117,17 @@
             <a class="btn primary block cta-pulse" id="btn-trial-card" target="_blank" rel="noreferrer">Agendar agora</a>
           </div>
         </div>
+        <form id="contact-form" class="card mt">
+          <h3>Envie uma mensagem</h3>
+          <label for="name">Nome</label>
+          <input type="text" id="name" name="name" required>
+          <label for="email">E-mail</label>
+          <input type="email" id="email" name="email" required>
+          <label for="message">Mensagem</label>
+          <textarea id="message" name="message" rows="5" required></textarea>
+          <div id="form-status" class="mt-sm muted"></div>
+          <button type="submit" class="btn primary block mt">Enviar</button>
+        </form>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- add contact form to the contact section
- handle submission with Formspree and display status messages
- style the form to match the site's theme

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a497077ad883308aa5c8d397aacac1