### PR TITLE
Add Vertentes XPACE section with gradient cards

### DIFF
--- a/xpace-landing/assets/css/styles.css
+++ b/xpace-landing/assets/css/styles.css
@@ -73,6 +73,11 @@ a:hover{opacity:.9}
 h2{font-size:28px;margin:0 0 16px 0}
 .card{padding:16px;border:1px solid var(--line);border-radius:var(--radius);background:rgba(255,255,255,.03)}
 
+/* Vertentes */
+.vert-card{display:flex;flex-direction:column;align-items:center;text-align:center;padding:24px}
+.vert-card .icon{font-size:40px;margin-bottom:8px}
+.grad-title{background:linear-gradient(90deg,var(--primary),var(--secondary));-webkit-background-clip:text;background-clip:text;color:transparent}
+
 /* Professores */
 .list-plain{list-style:none;margin:0;padding:0}
 .teacher-card{display:flex;gap:12px;align-items:center;padding:10px;border:1px solid var(--line);border-radius:14px;background:rgba(255,255,255,.03)}

--- a/xpace-landing/index.html
+++ b/xpace-landing/index.html
@@ -64,6 +64,50 @@
       </div>
     </section>
 
+    <!-- Vertentes XPACE -->
+    <section id="vertentes" class="section">
+      <div class="container">
+        <h2 class="reveal">Vertentes XPACE</h2>
+        <div class="grid three">
+          <div class="card vert-card">
+            <div class="icon">✨</div>
+            <h3 class="grad-title">XPACE</h3>
+            <p>Escola de dança e comunidade vibrante.</p>
+          </div>
+          <div class="card vert-card">
+            <div class="icon">🎓</div>
+            <h3 class="grad-title">Academy</h3>
+            <p>Aulas regulares para todos os níveis.</p>
+          </div>
+          <div class="card vert-card">
+            <div class="icon">👯‍♂️</div>
+            <h3 class="grad-title">Crew</h3>
+            <p>Companhia de competição.</p>
+          </div>
+          <div class="card vert-card">
+            <div class="icon">⭐</div>
+            <h3 class="grad-title">XPerience</h3>
+            <p>Imersões criativas e eventos especiais.</p>
+          </div>
+          <div class="card vert-card">
+            <div class="icon">🧪</div>
+            <h3 class="grad-title">Movement Lab</h3>
+            <p>Laboratório de pesquisa de movimento.</p>
+          </div>
+          <div class="card vert-card">
+            <div class="icon">🏕️</div>
+            <h3 class="grad-title">Dance Camp</h3>
+            <p>Intensivo de férias para dançarinos.</p>
+          </div>
+          <div class="card vert-card">
+            <div class="icon">🎬</div>
+            <h3 class="grad-title">Studio Experience</h3>
+            <p>Vivência completa em estúdio.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- Horários -->
     <section id="horarios" class="section">
       <div class="container">


### PR DESCRIPTION
## Summary
- introduce "Vertentes XPACE" section with responsive card grid and icons
- style card titles with purple-to-orange gradient and centralized layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baeaf807688330bb11c8df3b48e82e