### PR TITLE
Add Conquistas timeline section

### DIFF
--- a/xpace-landing/index.html
+++ b/xpace-landing/index.html
@@ -154,9 +154,32 @@
           <div id="form-status" class="mt-sm muted"></div>
           <button type="submit" class="btn primary block mt">Enviar</button>
         </form>
-      </div>
-    </section>
-  </main>
+        </div>
+      </section>
+
+      <!-- Conquistas -->
+      <section id="conquistas" class="section">
+        <div class="container">
+          <h2 class="reveal">Conquistas</h2>
+          <div class="timeline">
+            <div class="timeline-item reveal">
+              <div class="timeline-node">🏆</div>
+              <div class="timeline-content">
+                <strong>2024</strong>
+                <div class="mt-sm">HHU: 1º lugar Duo Junior • 1º lugar Small Crew Cadet • 2º lugar Small Crew Junior</div>
+              </div>
+            </div>
+            <div class="timeline-item reveal">
+              <div class="timeline-node">🏆</div>
+              <div class="timeline-content">
+                <strong>2025</strong>
+                <div class="mt-sm">HHI Brasil • Festival de Dança de Joinville</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
 
   <!-- Footer -->
   <footer class="site-footer">


### PR DESCRIPTION
## Summary
- add Conquistas timeline before the footer highlighting 2024 and 2025 achievements

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baeafb9eb8833092531803ade8c3b9