### PR TITLE
fix: clean class attributes in awards

### DIFF
--- a/xpace-landing/assets/js/app.js
+++ b/xpace-landing/assets/js/app.js
@@ -190,13 +190,13 @@ function renderHorarios(){
 (function renderAwards(){
   const wrap = $('#awards-timeline'); if (!wrap) return;
   AWARDS.forEach(a=>{
-    const note = a.note ? `<small class=\"muted block mt-sm\">${a.note}</small>` : '';
+    const note = a.note ? `<small class="muted block mt-sm">${a.note}</small>` : '';
     wrap.append($h(`
-      <div class=\"timeline-item reveal\">
-        <div class=\"timeline-node\">🏆</div>
-        <div class=\"timeline-content\">
+      <div class="timeline-item reveal">
+        <div class="timeline-node">🏆</div>
+        <div class="timeline-content">
           <strong>${a.year} — ${a.title}</strong>
-          <div class=\"mt-sm\">${a.desc}</div>
+          <div class="mt-sm">${a.desc}</div>
           ${note}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove unnecessary escape slashes in awards timeline markup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baf14b5d3483308689cbc47b66a723