### PR TITLE
Define default link destinations in HTML

### DIFF
--- a/xpace-landing/assets/js/app.js
+++ b/xpace-landing/assets/js/app.js
@@ -43,11 +43,8 @@ const $h = (html) => { const t = document.createElement('template'); t.innerHTML
 })();
 
 /* ===== Links ===== */
-const LINKS = {
-  trial: 'https://agendamento.nextfit.com.br/f9b1ea53-0e0e-4f98-9396-3dab7c9fbff4',
-  whats: 'https://wa.me/5547999463474?text=' + encodeURIComponent('Olá! Quero informações sobre matrículas na XPACE.'),
-  matriculas: 'https://venda.nextfit.com.br/54a0cf4a-176f-46d3-b552-aad35019a4ff/contratos'
-};
+const linkTrial = $('#btn-trial-nav')?.dataset.href || '';
+const linkMatriculas = $('#btn-matriculas')?.dataset.href || '';
 
 /* ===== Dados: Professores ===== */
 const TEACHERS = [
@@ -149,7 +146,7 @@ function renderHorarios(){
       const tag = h.reservado ? '🔒 Reservado' : (h.faixa || '');
       const cta = h.reservado ? '' : `
         <div class="mt">
-          <a class="btn small" target="_blank" rel="noreferrer" href="${LINKS.trial}">Agendar experimental</a>
+          <a class="btn small" target="_blank" rel="noreferrer" href="${linkTrial}">Agendar experimental</a>
           <a class="btn small ghost" target="_blank" rel="noreferrer"
              href="https://wa.me/5547999463474?text=${encodeURIComponent(`Olá! Quero reservar vaga em ${h.modalidade} • ${h.grupo} • ${h.nivel} (${weekName[dia]} ${h.hora}).`)}">
              WhatsApp
@@ -178,7 +175,7 @@ function renderHorarios(){
         <strong>${p.title}</strong>
         <div class="muted mt-sm">${p.price}</div>
         <div class="mt">
-          <a class="btn small primary" href="${LINKS.matriculas}" target="_blank" rel="noreferrer">Assinar</a>
+          <a class="btn small primary" href="${linkMatriculas}" target="_blank" rel="noreferrer">Assinar</a>
         </div>
       </li>
     `);
@@ -210,13 +207,11 @@ function renderHorarios(){
   const y = $('#year'); if (y) y.textContent = new Date().getFullYear();
 
   // links
-  $('#btn-trial-nav')?.setAttribute('href', LINKS.trial);
-  $('#btn-trial-hero')?.setAttribute('href', LINKS.trial);
-  $('#btn-trial-card')?.setAttribute('href', LINKS.trial);
-  $('#btn-whats-hero')?.setAttribute('href', LINKS.whats);
-  $('#link-whats')?.setAttribute('href', LINKS.whats);
+  ['btn-trial-nav','btn-trial-hero','btn-trial-card','btn-whats-hero','link-whats','btn-matriculas'].forEach(id=>{
+    const el = document.getElementById(id);
+    if (el?.dataset.href) el.setAttribute('href', el.dataset.href);
+  });
   if ($('#link-whats')) $('#link-whats').textContent = '+55 47 99946‑3474';
-  $('#btn-matriculas')?.setAttribute('href', LINKS.matriculas);
 
   // filtros de horários
   const fDia = $('#filter-dia');

--- a/xpace-landing/index.html
+++ b/xpace-landing/index.html
@@ -35,9 +35,9 @@
         <a href="#premiacoes">Premiações</a>
         <a href="#faq">FAQ</a>
         <a href="#contato">Contato</a>
-        <a class="btn small ghost" id="btn-trial-nav" target="_blank" rel="noreferrer">Aula experimental</a>
+        <a class="btn small ghost" id="btn-trial-nav" target="_blank" rel="noreferrer" href="https://agendamento.nextfit.com.br/f9b1ea53-0e0e-4f98-9396-3dab7c9fbff4" data-href="https://agendamento.nextfit.com.br/f9b1ea53-0e0e-4f98-9396-3dab7c9fbff4">Aula experimental</a>
       </nav>
-      <a class="btn primary pill cta-pulse" id="btn-matriculas" target="_blank" rel="noreferrer">Matrículas</a>
+      <a class="btn primary pill cta-pulse" id="btn-matriculas" target="_blank" rel="noreferrer" href="https://venda.nextfit.com.br/54a0cf4a-176f-46d3-b552-aad35019a4ff/contratos" data-href="https://venda.nextfit.com.br/54a0cf4a-176f-46d3-b552-aad35019a4ff/contratos">Matrículas</a>
       <button id="theme-toggle" class="btn small ghost" aria-label="Alternar tema">🌙</button>
       <button class="burger" aria-label="Abrir menu" aria-expanded="false"></button>
     </div>
@@ -59,8 +59,8 @@
             Aulas para todas as idades e níveis. Companhia de competição e comunidade vibrante.
           </p>
           <div class="cta-row">
-            <a class="btn primary cta-pulse" id="btn-whats-hero" target="_blank" rel="noreferrer" aria-label="Iniciar matrícula pelo WhatsApp">Matricule-se no WhatsApp</a>
-            <a class="btn" id="btn-trial-hero" target="_blank" rel="noreferrer" aria-label="Agendar aula experimental">Agendar aula experimental</a>
+            <a class="btn primary cta-pulse" id="btn-whats-hero" target="_blank" rel="noreferrer" aria-label="Iniciar matrícula pelo WhatsApp" href="https://wa.me/5547999463474?text=Ol%C3%A1!%20Quero%20informa%C3%A7%C3%B5es%20sobre%20matr%C3%ADculas%20na%20XPACE." data-href="https://wa.me/5547999463474?text=Ol%C3%A1!%20Quero%20informa%C3%A7%C3%B5es%20sobre%20matr%C3%ADculas%20na%20XPACE.">Matricule-se no WhatsApp</a>
+            <a class="btn" id="btn-trial-hero" target="_blank" rel="noreferrer" aria-label="Agendar aula experimental" href="https://agendamento.nextfit.com.br/f9b1ea53-0e0e-4f98-9396-3dab7c9fbff4" data-href="https://agendamento.nextfit.com.br/f9b1ea53-0e0e-4f98-9396-3dab7c9fbff4">Agendar aula experimental</a>
             <a class="btn ghost" href="#horarios" aria-label="Ver grade de horários">Ver horários</a>
           </div>
           <small class="muted block mt-sm">
@@ -209,7 +209,7 @@
         <div class="grid two">
           <div>
             <p>
-              <b>WhatsApp:</b> <a id="link-whats" target="_blank" rel="noreferrer"></a><br>
+              <b>WhatsApp:</b> <a id="link-whats" target="_blank" rel="noreferrer" href="https://wa.me/5547999463474?text=Ol%C3%A1!%20Quero%20informa%C3%A7%C3%B5es%20sobre%20matr%C3%ADculas%20na%20XPACE." data-href="https://wa.me/5547999463474?text=Ol%C3%A1!%20Quero%20informa%C3%A7%C3%B5es%20sobre%20matr%C3%ADculas%20na%20XPACE.">+55 47 99946‑3474</a><br>
               <b>Instagram:</b> <a href="https://instagram.com/xpacedance" target="_blank" rel="noreferrer">@xpacedance</a><br>
               <b>TikTok:</b> <a href="https://tiktok.com/@xpacedance" target="_blank" rel="noreferrer">@xpacedance</a><br>
               <b>YouTube:</b> <a href="https://www.youtube.com/@xpacedancecompany" target="_blank" rel="noreferrer">XPACE Dance Company</a><br>
@@ -220,7 +220,7 @@
           <div class="card">
             <h3>Agende sua experimental</h3>
             <p>Integração oficial Nextfit:</p>
-            <a class="btn primary block cta-pulse" id="btn-trial-card" target="_blank" rel="noreferrer">Agendar agora</a>
+            <a class="btn primary block cta-pulse" id="btn-trial-card" target="_blank" rel="noreferrer" href="https://agendamento.nextfit.com.br/f9b1ea53-0e0e-4f98-9396-3dab7c9fbff4" data-href="https://agendamento.nextfit.com.br/f9b1ea53-0e0e-4f98-9396-3dab7c9fbff4">Agendar agora</a>
           </div>
         </div>
         <form id="contact-form" class="card mt">


### PR DESCRIPTION
## Summary
- Add default `href` and `data-href` to navigation, hero, contact and card links.
- Update `app.js` to read URLs from `data-href` attributes for dynamic usage.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baf23c0e788330903520f898595e07