### PR TITLE
Add Three.js hero background animation

### DIFF
--- a/xpace-landing/assets/js/app.js
+++ b/xpace-landing/assets/js/app.js
@@ -269,11 +269,72 @@ function initUI(){
   }
 }
 
+/* ===== Hero background ===== */
+function initHeroBackground(){
+  const canvas = document.getElementById('bg-canvas');
+  if (!canvas || typeof THREE === 'undefined') return;
+
+  const hasWebGL = (()=>{
+    try {
+      const c = document.createElement('canvas');
+      return !!window.WebGLRenderingContext && (
+        c.getContext('webgl') || c.getContext('experimental-webgl')
+      );
+    } catch(e){
+      return false;
+    }
+  })();
+  if (!hasWebGL){
+    canvas.remove();
+    return;
+  }
+
+  const hero = document.querySelector('.hero');
+  if (hero) hero.style.position = 'relative';
+  canvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;z-index:-1;pointer-events:none;';
+
+  const renderer = new THREE.WebGLRenderer({canvas,alpha:true});
+  renderer.setPixelRatio(window.devicePixelRatio);
+  renderer.setSize(window.innerWidth, window.innerHeight);
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(60, window.innerWidth/window.innerHeight, 1, 1000);
+  camera.position.z = 400;
+
+  const particles = new THREE.BufferGeometry();
+  const count = 600;
+  const positions = new Float32Array(count * 3);
+  for(let i=0;i<count;i++){
+    positions[i*3]   = (Math.random()*2-1) * 400;
+    positions[i*3+1] = (Math.random()*2-1) * 400;
+    positions[i*3+2] = (Math.random()*2-1) * 400;
+  }
+  particles.setAttribute('position', new THREE.BufferAttribute(positions,3));
+  const material = new THREE.PointsMaterial({color:0xffffff, size:2});
+  const points = new THREE.Points(particles, material);
+  scene.add(points);
+
+  function animate(){
+    requestAnimationFrame(animate);
+    points.rotation.y += 0.0008;
+    points.rotation.x += 0.0005;
+    renderer.render(scene, camera);
+  }
+  animate();
+
+  window.addEventListener('resize', ()=>{
+    camera.aspect = window.innerWidth/window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+  });
+}
+
 loadData().then(()=>{
   renderTeachers();
   renderPlans();
   renderAwards();
   initUI();
+  initHeroBackground();
 });
 
 /* ===== Loader ===== */

--- a/xpace-landing/index.html
+++ b/xpace-landing/index.html
@@ -46,6 +46,7 @@
   <!-- Hero -->
   <main id="top">
     <section class="hero">
+      <canvas id="bg-canvas"></canvas>
       <div class="container hero-grid">
         <div class="hero-copy">
           <div class="pill light">Matrículas abertas • Joinville/SC</div>
@@ -273,6 +274,7 @@
     </div>
   </footer>
 
+  <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
   <script src="assets/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add background canvas and include Three.js
- implement `initHeroBackground` for animated particles with WebGL fallback
- initialize hero background after UI setup

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bafae514488330ad10ad6464972153